### PR TITLE
Remove `<abbr>` tag from au-body examples

### DIFF
--- a/content/_data.yml
+++ b/content/_data.yml
@@ -2,42 +2,42 @@
 # THE `pancake` and `auds` FIELDS WILL BE OVERWRITTEN
 
 pancake:
-  downloads: 169751
+  downloads: 170309
   modules:
-    '@gov.au/pancake': 38443
-    '@gov.au/pancake-js': 25648
-    '@gov.au/pancake-json': 31677
-    '@gov.au/pancake-react': 32052
-    '@gov.au/pancake-sass': 40815
-    '@gov.au/syrup': 1116
+    '@gov.au/pancake': 38526
+    '@gov.au/pancake-js': 25743
+    '@gov.au/pancake-json': 31808
+    '@gov.au/pancake-react': 32191
+    '@gov.au/pancake-sass': 40924
+    '@gov.au/syrup': 1117
   stars: 79
 auds:
-  downloads: 486718
+  downloads: 486734
   modules:
-    '@gov.au/accordion': 24566
-    '@gov.au/animate': 23925
-    '@gov.au/body': 28111
-    '@gov.au/breadcrumbs': 17848
-    '@gov.au/buttons': 27649
-    '@gov.au/callout': 12609
-    '@gov.au/control-input': 15193
-    '@gov.au/core': 31640
-    '@gov.au/cta-link': 21270
-    '@gov.au/direction-links': 11407
-    '@gov.au/footer': 25106
+    '@gov.au/accordion': 24597
+    '@gov.au/animate': 23935
+    '@gov.au/body': 28122
+    '@gov.au/breadcrumbs': 17866
+    '@gov.au/buttons': 27629
+    '@gov.au/callout': 12594
+    '@gov.au/control-input': 15173
+    '@gov.au/core': 31642
+    '@gov.au/cta-link': 21292
+    '@gov.au/direction-links': 11394
+    '@gov.au/footer': 25092
     '@gov.au/grid-12': 26068
-    '@gov.au/header': 21494
-    '@gov.au/headings': 17090
-    '@gov.au/inpage-nav': 13828
-    '@gov.au/keyword-list': 9237
-    '@gov.au/link-list': 25522
-    '@gov.au/main-nav': 4683
-    '@gov.au/page-alerts': 20265
-    '@gov.au/progress-indicator': 10649
-    '@gov.au/responsive-media': 12750
-    '@gov.au/select': 18551
-    '@gov.au/side-nav': 5572
-    '@gov.au/skip-link': 21740
-    '@gov.au/tags': 16628
-    '@gov.au/text-inputs': 23317
-  stars: 490
+    '@gov.au/header': 21501
+    '@gov.au/headings': 17048
+    '@gov.au/inpage-nav': 13821
+    '@gov.au/keyword-list': 9220
+    '@gov.au/link-list': 25510
+    '@gov.au/main-nav': 4695
+    '@gov.au/page-alerts': 20284
+    '@gov.au/progress-indicator': 10630
+    '@gov.au/responsive-media': 12775
+    '@gov.au/select': 18566
+    '@gov.au/side-nav': 5592
+    '@gov.au/skip-link': 21759
+    '@gov.au/tags': 16646
+    '@gov.au/text-inputs': 23283
+  stars: 494

--- a/content/_data.yml
+++ b/content/_data.yml
@@ -2,42 +2,42 @@
 # THE `pancake` and `auds` FIELDS WILL BE OVERWRITTEN
 
 pancake:
-  downloads: 170309
+  downloads: 171027
   modules:
-    '@gov.au/pancake': 38526
-    '@gov.au/pancake-js': 25743
-    '@gov.au/pancake-json': 31808
-    '@gov.au/pancake-react': 32191
-    '@gov.au/pancake-sass': 40924
-    '@gov.au/syrup': 1117
+    '@gov.au/pancake': 38698
+    '@gov.au/pancake-js': 25834
+    '@gov.au/pancake-json': 31980
+    '@gov.au/pancake-react': 32308
+    '@gov.au/pancake-sass': 41091
+    '@gov.au/syrup': 1116
   stars: 79
 auds:
-  downloads: 486734
+  downloads: 487134
   modules:
-    '@gov.au/accordion': 24597
-    '@gov.au/animate': 23935
-    '@gov.au/body': 28122
-    '@gov.au/breadcrumbs': 17866
-    '@gov.au/buttons': 27629
-    '@gov.au/callout': 12594
-    '@gov.au/control-input': 15173
-    '@gov.au/core': 31642
-    '@gov.au/cta-link': 21292
-    '@gov.au/direction-links': 11394
-    '@gov.au/footer': 25092
-    '@gov.au/grid-12': 26068
-    '@gov.au/header': 21501
-    '@gov.au/headings': 17048
-    '@gov.au/inpage-nav': 13821
-    '@gov.au/keyword-list': 9220
-    '@gov.au/link-list': 25510
-    '@gov.au/main-nav': 4695
-    '@gov.au/page-alerts': 20284
-    '@gov.au/progress-indicator': 10630
-    '@gov.au/responsive-media': 12775
-    '@gov.au/select': 18566
-    '@gov.au/side-nav': 5592
-    '@gov.au/skip-link': 21759
-    '@gov.au/tags': 16646
-    '@gov.au/text-inputs': 23283
-  stars: 494
+    '@gov.au/accordion': 24621
+    '@gov.au/animate': 23966
+    '@gov.au/body': 28160
+    '@gov.au/breadcrumbs': 17887
+    '@gov.au/buttons': 27641
+    '@gov.au/callout': 12570
+    '@gov.au/control-input': 15165
+    '@gov.au/core': 31777
+    '@gov.au/cta-link': 21314
+    '@gov.au/direction-links': 11373
+    '@gov.au/footer': 25105
+    '@gov.au/grid-12': 26083
+    '@gov.au/header': 21527
+    '@gov.au/headings': 17026
+    '@gov.au/inpage-nav': 13812
+    '@gov.au/keyword-list': 9203
+    '@gov.au/link-list': 25533
+    '@gov.au/main-nav': 4711
+    '@gov.au/page-alerts': 20310
+    '@gov.au/progress-indicator': 10617
+    '@gov.au/responsive-media': 12766
+    '@gov.au/select': 18601
+    '@gov.au/side-nav': 5603
+    '@gov.au/skip-link': 21789
+    '@gov.au/tags': 16671
+    '@gov.au/text-inputs': 23303
+  stars: 498

--- a/content/_data.yml
+++ b/content/_data.yml
@@ -2,42 +2,42 @@
 # THE `pancake` and `auds` FIELDS WILL BE OVERWRITTEN
 
 pancake:
-  downloads: 167722
+  downloads: 169751
   modules:
-    '@gov.au/pancake': 37640
-    '@gov.au/pancake-js': 25431
-    '@gov.au/pancake-json': 31346
-    '@gov.au/pancake-react': 31803
-    '@gov.au/pancake-sass': 40396
-    '@gov.au/syrup': 1106
+    '@gov.au/pancake': 38443
+    '@gov.au/pancake-js': 25648
+    '@gov.au/pancake-json': 31677
+    '@gov.au/pancake-react': 32052
+    '@gov.au/pancake-sass': 40815
+    '@gov.au/syrup': 1116
   stars: 79
 auds:
-  downloads: 483905
+  downloads: 486718
   modules:
-    '@gov.au/accordion': 24369
-    '@gov.au/animate': 23785
-    '@gov.au/body': 27983
-    '@gov.au/breadcrumbs': 17724
-    '@gov.au/buttons': 27581
-    '@gov.au/callout': 12545
-    '@gov.au/control-input': 15194
-    '@gov.au/core': 31442
-    '@gov.au/cta-link': 21118
-    '@gov.au/direction-links': 11338
-    '@gov.au/footer': 25028
-    '@gov.au/grid-12': 25984
-    '@gov.au/header': 21395
-    '@gov.au/headings': 17060
-    '@gov.au/inpage-nav': 13715
-    '@gov.au/keyword-list': 9173
-    '@gov.au/link-list': 25438
-    '@gov.au/main-nav': 4575
-    '@gov.au/page-alerts': 20132
-    '@gov.au/progress-indicator': 10599
-    '@gov.au/responsive-media': 12598
-    '@gov.au/select': 18443
-    '@gov.au/side-nav': 5395
-    '@gov.au/skip-link': 21611
-    '@gov.au/tags': 16515
-    '@gov.au/text-inputs': 23165
-  stars: 477
+    '@gov.au/accordion': 24566
+    '@gov.au/animate': 23925
+    '@gov.au/body': 28111
+    '@gov.au/breadcrumbs': 17848
+    '@gov.au/buttons': 27649
+    '@gov.au/callout': 12609
+    '@gov.au/control-input': 15193
+    '@gov.au/core': 31640
+    '@gov.au/cta-link': 21270
+    '@gov.au/direction-links': 11407
+    '@gov.au/footer': 25106
+    '@gov.au/grid-12': 26068
+    '@gov.au/header': 21494
+    '@gov.au/headings': 17090
+    '@gov.au/inpage-nav': 13828
+    '@gov.au/keyword-list': 9237
+    '@gov.au/link-list': 25522
+    '@gov.au/main-nav': 4683
+    '@gov.au/page-alerts': 20265
+    '@gov.au/progress-indicator': 10649
+    '@gov.au/responsive-media': 12750
+    '@gov.au/select': 18551
+    '@gov.au/side-nav': 5572
+    '@gov.au/skip-link': 21740
+    '@gov.au/tags': 16628
+    '@gov.au/text-inputs': 23317
+  stars: 490

--- a/content/components/_all.yml
+++ b/content/components/_all.yml
@@ -532,7 +532,7 @@ control-input:
     - open: 2
     - active: 7
     - something: something
-  version: 2.2.1    # <-- auto generated, don't change
+  version: 2.2.2    # <-- auto generated, don't change
   dependencies:    # <-- auto generated, don't change
     - core
   hasSass: true    # <-- auto generated, don't change

--- a/content/components/body/accessibility/example-code.md
+++ b/content/components/body/accessibility/example-code.md
@@ -1,6 +1,6 @@
 <div class="au-body">
   <h1>Example heading</h1>
-  <p>Example paragraph with an <a href="#" class="js-focus-me">Internal link</a> and an <a href="#" rel="external" class="js-focus-me">External link</a> and <abbr title="abbreviation">abbr</abbr>.</p>
+  <p>Example paragraph with an <a href="#" class="js-focus-me">Internal link</a> and an <a href="#" rel="external" class="js-focus-me">External link</a>.</p>
   <hr>
   <p>Example formula: <var>E</var>=<var>m</var><var>c</var><sup>2</sup>f(<var>x</var>, <var>n</var>) = log<sub>4</sub><var>x</var><sup><var>n</var></sup></p>
   <p>

--- a/content/components/body/accessibility/example-dark.md
+++ b/content/components/body/accessibility/example-dark.md
@@ -1,6 +1,6 @@
 <div class="au-body au-body--dark">
   <h1>Example heading</h1>
-  <p>Example paragraph with an <a href="#" class="js-focus-me">Internal link</a> and an <a href="#" rel="external" class="js-focus-me">External link</a> and <abbr title="abbreviation">abbr</abbr>.</p>
+  <p>Example paragraph with an <a href="#" class="js-focus-me">Internal link</a> and an <a href="#" rel="external" class="js-focus-me">External link</a>.</p>
   <hr>
   <p>Example formula: <var>E</var>=<var>m</var><var>c</var><sup>2</sup>f(<var>x</var>, <var>n</var>) = log<sub>4</sub><var>x</var><sup><var>n</var></sup></p>
   <p>

--- a/content/components/body/accessibility/screenreader.md
+++ b/content/components/body/accessibility/screenreader.md
@@ -5,8 +5,7 @@ speak: |
 
   [Heading level 1] Example heading.
 
-  Example paragraph with an, [link] internal link, and an, [link] external link, and [abbreviation group] abbreviation.
-
+  Example paragraph with an, [link] internal link, and an, [link] external link.
   [horizontal splitter].
 
   Example formula, E equals m c, two, f, x, n, equals log, four, x n.

--- a/content/components/body/accessibility/screenreader.md
+++ b/content/components/body/accessibility/screenreader.md
@@ -5,7 +5,7 @@ speak: |
 
   [Heading level 1] Example heading.
 
-  Example paragraph with an, [link] internal link, and an, [link] external link.
+  Example paragraph with an, [link] internal link and an [link] external link.
   [horizontal splitter].
 
   Example formula, E equals m c, two, f, x, n, equals log, four, x n.

--- a/content/components/body/examples/example-type/example-code.md
+++ b/content/components/body/examples/example-type/example-code.md
@@ -2,5 +2,5 @@
   <h2>Heading level 2</h2>
   <p>Example paragraph. <a href="#">Internal link</a> and an <a href="#" rel="external">external link</a>.</p>
   <hr>
-  <p>Lorem, <abbr title="Web Content Accessibility Guidelines">WCAG</abbr> ipsum dolor sit amet consectetur adipisicing elit.</p>
+  <p>Lorem, Web Content Accessibility Guidelines (WCAG) ipsum dolor sit amet consectetur adipisicing elit.</p>
 </div>

--- a/content/components/body/examples/example-type/example-dark.md
+++ b/content/components/body/examples/example-type/example-dark.md
@@ -2,5 +2,5 @@
   <h2>Heading level 2</h2>
   <p>Example paragraph. <a href="#">Internal link</a> and an <a href="#" rel="external">external link</a>.</p>
   <hr>
-  <p>Lorem, <abbr title="Web Content Accessibility Guidelines">WCAG</abbr> ipsum dolor sit amet consectetur adipisicing elit.</p>
+  <p>Lorem, Web Content Accessibility Guidelines (WCAG) ipsum dolor sit amet consectetur adipisicing elit.</p>
 </div>

--- a/content/components/body/rationale/abbreviation.md
+++ b/content/components/body/rationale/abbreviation.md
@@ -3,9 +3,10 @@ layout: component/rationale.js
 heading: Abbreviations
 ---
 
-Screen reader support for the `<abbr>` element is [limited](https://www.powermapper.com/tests/screen-readers/labelling/acronym-abbr-title/). Abbreviations should be done in accordance with [readability guidelines](https://www.w3.org/TR/WCAG20-TECHS/G97.html). This means use contextual abbreviation for the first mention, and using the abbreviated term in future mentions.
+Screen reader support for the `<abbr>` element is [limited](https://www.powermapper.com/tests/screen-readers/labelling/acronym-abbr-title/) and use of this element should be avoided. Abbreviations should be handled in accordance with [readability guidelines](https://guides.service.gov.au/content-guide/terms-phrases/#acronyms) defined in the content guide. This means use contextual abbreviation for the first mention, and using the abbreviated term in future mentions.
+
 As an example:
 
 > Lorem ipsum Web Content Authoring Guideline (WCAG) ipsum dolor sit amet. Quisquam totam perspiciatis WCAG oluta et reiciendis expedita suscipit culpa id.
 
-This way the reading-experience of a screen reader more closely user matches that of a non screen reader user.
+The W3C (World Wide Web Consortium) provide a [similar example](https://www.w3.org/TR/WCAG20-TECHS/G97.html). This way the reading-experience of a screen reader more closely user matches that of a non screen reader user.

--- a/content/components/body/rationale/abbreviation.md
+++ b/content/components/body/rationale/abbreviation.md
@@ -1,0 +1,6 @@
+---
+layout: component/rationale.js
+heading: Abbreviation
+---
+
+Screenreader support for the `<abbr>` element is limited. 

--- a/content/components/body/rationale/abbreviation.md
+++ b/content/components/body/rationale/abbreviation.md
@@ -3,10 +3,10 @@ layout: component/rationale.js
 heading: Abbreviations
 ---
 
-Screen reader support for the `<abbr>` element is [limited](https://www.powermapper.com/tests/screen-readers/labelling/acronym-abbr-title/) and use of this element should be avoided. Abbreviations should be handled in accordance with [readability guidelines](https://guides.service.gov.au/content-guide/terms-phrases/#acronyms) defined in the content guide. This means use contextual abbreviation for the first mention, and using the abbreviated term in future mentions.
+Screen reader support for the `<abbr>` element is [limited](https://www.powermapper.com/tests/screen-readers/labelling/acronym-abbr-title/) and use of this element should be avoided. Abbreviations should be done in accordance with [readability guidelines](https://guides.service.gov.au/content-guide/terms-phrases/#acronyms) defined in the content guide. This means use contextual abbreviation for the first mention, and using the abbreviated term in future mentions.
 
 As an example:
 
-> Lorem ipsum Web Content Authoring Guideline (WCAG) ipsum dolor sit amet. Quisquam totam perspiciatis WCAG oluta et reiciendis expedita suscipit culpa id.
+> The Australian Football League (AFL) has 18 teams. The AFL was founded in 1896...
 
 The W3C (World Wide Web Consortium) provide a [similar example](https://www.w3.org/TR/WCAG20-TECHS/G97.html). This way the reading-experience of a screen reader more closely user matches that of a non screen reader user.

--- a/content/components/body/rationale/abbreviation.md
+++ b/content/components/body/rationale/abbreviation.md
@@ -1,6 +1,11 @@
 ---
 layout: component/rationale.js
-heading: Abbreviation
+heading: Abbreviations
 ---
 
-Screenreader support for the `<abbr>` element is limited. 
+Screen reader support for the `<abbr>` element is [limited](https://www.powermapper.com/tests/screen-readers/labelling/acronym-abbr-title/). Abbreviations should be done in accordance with [readability guidelines](https://www.w3.org/TR/WCAG20-TECHS/G97.html). This means use contextual abbreviation for the first mention, and using the abbreviated term in future mentions.
+As an example:
+
+> Lorem ipsum Web Content Authoring Guideline (WCAG) ipsum dolor sit amet. Quisquam totam perspiciatis WCAG oluta et reiciendis expedita suscipit culpa id.
+
+This way the reading-experience of a screen reader more closely user matches that of a non screen reader user.

--- a/content/components/body/rationale/index.yml
+++ b/content/components/body/rationale/index.yml
@@ -14,6 +14,7 @@ sidebar:
 main:
   - max-width.md
   - horizontal-separator.md
+  - abbreviation.md
 
 footer:
   - /_shared/footer.md

--- a/content/components/body/type.md
+++ b/content/components/body/type.md
@@ -28,3 +28,4 @@ Body includes a range of styles for basic content elements.
 - [Paragraph](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)
 - [Links](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)
 - [Horizontal rule](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr)
+- [Acronyms](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr)

--- a/content/components/body/type.md
+++ b/content/components/body/type.md
@@ -17,7 +17,7 @@ code:
         </p>
         <hr />
         <p>
-          Lorem, WCAG (Web Content Accessibility Guidelines) ipsum dolor sit amet consectetur adipisicing elit.
+          Lorem, Web Content Accessibility Guidelines (WCAG) ipsum dolor sit amet consectetur adipisicing elit.
         </p>
       </div>
 ---

--- a/content/components/body/type.md
+++ b/content/components/body/type.md
@@ -17,7 +17,7 @@ code:
         </p>
         <hr />
         <p>
-          Lorem, <abbr title="Web Content Accessibility Guidelines">WCAG</abbr> ipsum dolor sit amet consectetur adipisicing elit.
+          Lorem, WCAG (Web Content Accessibility Guidelines) ipsum dolor sit amet consectetur adipisicing elit.
         </p>
       </div>
 ---
@@ -28,4 +28,3 @@ Body includes a range of styles for basic content elements.
 - [Paragraph](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p)
 - [Links](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)
 - [Horizontal rule](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr)
-- [Acronyms](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr)


### PR DESCRIPTION
Screen reader support for `<abbr>` is [limited ](https://www.powermapper.com/tests/screen-readers/labelling/acronym-abbr-title/), so we should do our abbreviations in accordance with [readability guidelines](https://guides.service.gov.au/content-guide/terms-phrases/#acronyms).

This way the reading-experience of a screen reader more closely user matches that of a non screen reader user.

In reference to govau/design-system-components#596