### PR TITLE
Use button instead of anchor for accordion

### DIFF
--- a/src/layout/navigation-accordion.js
+++ b/src/layout/navigation-accordion.js
@@ -45,13 +45,13 @@ const NavigationAccordion = ({ navItems, _relativeURL, _ID, _pages }) => {
 					links.length
 						?
 						<section className="au-accordion">
-							<a href={ `#accordion-${ title }` }
+							<button href={ `#accordion-${ title }` }
 								className={ `au-accordion__title js-accordion${ _isOpen ? '' : ' au-accordion--closed' }` }
 								aria-controls={ `accordion-${ title }` }
 								aria-expanded={ _isOpen ? 'true' : 'false' }
 								onClick="return AUDS.accordion.Toggle( this )">
 									{ title } <span className={ `badge badge--${ title }` }>{ links.length }</span>
-							</a>
+							</button>
 							<div
 								className={ `au-accordion__body${ _isOpen ? '' : ' au-accordion--closed' }` }
 								id={ `accordion-${ title }` }


### PR DESCRIPTION
Our sidebar accordion on the components page uses an anchor tag when it should use a button.

As brought up by @decrepidos