### PR TITLE
Update incorrect attribute for anchor tags in button docs

### DIFF
--- a/content/components/select/disabled.md
+++ b/content/components/select/disabled.md
@@ -5,7 +5,7 @@ code:
   - HTML: |
       <!--
       Light: <select class="au-select" disabled>
-      Dark:  <label class="au-select au-select--dark" disabled>
+      Dark:  <select class="au-select au-select--dark" disabled>
       -->
 
       <label for="select1disabled">What option?</label>

--- a/content/components/select/disabled.md
+++ b/content/components/select/disabled.md
@@ -4,7 +4,7 @@ iframe: examples/example-disabled
 code:
   - HTML: |
       <!--
-      Light: <label class="au-select" disabled>
+      Light: <select class="au-select" disabled>
       Dark:  <label class="au-select au-select--dark" disabled>
       -->
 

--- a/content/components/select/valid-invalid.md
+++ b/content/components/select/valid-invalid.md
@@ -5,7 +5,7 @@ iframeFullwidth: true
 code:
   - HTML: |
       <!--
-      Valid:    <label class="au-select au-select--valid">
+      Valid:    <select class="au-select au-select--valid">
       Invalid:  <select class="au-select au-select--invalid">
       -->
 

--- a/content/components/select/valid-invalid.md
+++ b/content/components/select/valid-invalid.md
@@ -46,4 +46,4 @@ code:
 ---
 ## Valid and invalid states
 
-Use the `.au-select--valid` class to add a border around the select to indicate valid or invalid selections.
+Add a border around select boxes to indicate whether user input is valid or invalid.


### PR DESCRIPTION
The anchor tag was using a `link` attribute when it should have been using a `href` attribute. 

Nice work @KiriHoy 

Fixes #445 