### PR TITLE
Hotfix - search button not taking up full width

### DIFF
--- a/src/layout/search.js
+++ b/src/layout/search.js
@@ -11,7 +11,7 @@ const Searchbox = ({ label, placeholder, _relativeURL, _ID, _pages }) => (
 		<label className="sronly" htmlFor="s1">{ label }</label>
 
 		<div className="au-stretch_col-fill">
-			<AUtextInput name="s" id="s1" type="search" placeholder={ placeholder } defaultValue={ _pages[ _ID ].searchvalue && _pages[ _ID ].searchvalue } />
+			<AUtextInput block name="s" id="s1" type="search" placeholder={ placeholder } defaultValue={ _pages[ _ID ].searchvalue && _pages[ _ID ].searchvalue } />
 		</div>
 
 		<div className="au-stretch_col-fit">


### PR DESCRIPTION
fixes #471 
funky...most likely due to the updates on text inputs

![image](https://user-images.githubusercontent.com/20184809/54245997-37c3ef80-4587-11e9-90fe-ce4773bf134c.png)

Thanks to @MattFredBrooks for bringing  it up! Thanks also to @pattyde for picking it up!

fixes #471 