### PR TITLE
Fix bug where select was not adding components to the npm copy list

### DIFF
--- a/src/js/footer/050-furnace-code.js
+++ b/src/js/footer/050-furnace-code.js
@@ -71,6 +71,7 @@ function ClearNPM() {
  */ 
 AddEvent( furnaceSelectAll, "click", function() {
 	for ( i = 0; i < furnaceComponents.length; i++ ) {
-		furnaceComponents[ i ].checked = true;		
+		furnaceComponents[ i ].checked = true;	
+		ToggleNPM( furnaceComponents[ i ] );
 	}
 })


### PR DESCRIPTION
A bug was identified where, when the select all button was clicked and all the checkboxes were checked, these elements were not added to the NPM copy list ( ie. such as in screenshot) 
<img width="276" alt="Screen Shot 2019-03-28 at 9 43 40 am" src="https://user-images.githubusercontent.com/34221033/55117216-1a258700-513e-11e9-8eae-42cc0f91b5aa.png">

