### PR TITLE
Update starter docs, types for text inputs

### DIFF
--- a/content/components/footer/default.md
+++ b/content/components/footer/default.md
@@ -34,7 +34,7 @@ code:
             <div class="col-sm-12">
               <div class="au-footer__end">
                 <p>Footer text</p>
-                <img class="au-responsive-media-img" src="/assets/img/placeholder/157x80.png" alt="Brand image">
+                <img class="au-responsive-media-img" src="https://designsystem.gov.au/assets/img/placeholder/157x80.png" alt="Brand image">
                 <p><small>&copy; Commonwealth of Australia, <a href="https://github.com/govau/design-system-components/blob/master/LICENSE.md" rel="external license">MIT licensed</a></small></p>
               </div>
             </div>
@@ -77,7 +77,7 @@ code:
               <div className="col-sm-12">
                 <AUfooterEnd>
                   <p>Footer text</p>
-                  <img className="au-responsive-media-img" src="/assets/img/placeholder/157x80.png" alt="Brand image" />
+                  <img className="au-responsive-media-img" src="https://designsystem.gov.au/assets/img/placeholder/157x80.png" alt="Brand image" />
                   <p><small>&copy; Commonwealth of Australia, <a href="https://github.com/govau/design-system-components/blob/master/LICENSE.md" rel="external license">MIT licensed</a></small></p>
                 </AUfooterEnd>
               </div>

--- a/content/components/header/code/react-usage.md
+++ b/content/components/header/code/react-usage.md
@@ -10,7 +10,7 @@ import AUheader, { AUheaderBrand } from './header.js';
 <AUheader>
 	<AUheaderBrand
 		link="#"
-		brandImage="/assets/img/placeholder/256x80.png"
+		brandImage="https://designsystem.gov.au/assets/img/placeholder/256x80.png"
 		brandImageAlt="Digital Transformation Agency"
 	/>
 </AUheader>

--- a/content/components/header/default.md
+++ b/content/components/header/default.md
@@ -14,7 +14,7 @@ code:
           <div class="row">
             <div class="col-md-9">
               <a class="au-header__brand" href="#">
-                <img class="au-header__brand-image" alt="Insert alternate text here" src="/assets/img/placeholder/256x80.png">
+                <img class="au-header__brand-image" alt="Insert alternate text here" src="https://designsystem.gov.au/assets/img/placeholder/256x80.png">
                 <div class="au-header__text">
                   <h1 class="au-header__heading">Site title</h1>
                   <div class="au-header__subline">
@@ -43,7 +43,7 @@ code:
                 title="Page title" 
                 subline="Service sub-title that could be a little longer"
                 link="#"
-                brandImage="/assets/img/placeholder/256x80.png"
+                brandImage="https://designsystem.gov.au/assets/img/placeholder/256x80.png"
                 brandImageAlt="Insert alternate text here"
               />
             </div>

--- a/content/components/header/hero.md
+++ b/content/components/header/hero.md
@@ -14,7 +14,7 @@ code:
           <div class="row">
             <div class="col-md-9">
               <div class="au-header__brand">
-                <img class="au-header__brand-image" alt="Insert alternate text here" src="/assets/img/placeholder/256x80.png">
+                <img class="au-header__brand-image" alt="Insert alternate text here" src="https://designsystem.gov.au/assets/img/placeholder/256x80.png">
                 <div class="au-header__text">
                   <h1 class="au-header__heading">Site title</h1>
                   <div class="au-header__subline">
@@ -43,7 +43,7 @@ code:
                 title="Page title" 
                 subline="Service sub-title that could be a little longer"
                 link="#"
-                brandImage="/assets/img/placeholder/256x80.png"
+                brandImage="https://designsystem.gov.au/assets/img/placeholder/256x80.png"
                 brandImageAlt="Insert alternate text here"
               />
             </div>

--- a/content/get-started/content.md
+++ b/content/get-started/content.md
@@ -2,7 +2,7 @@
 
 There are many ways to get started with the Australian Government Design System. It all depends on your project's needs and whether you are a developer or a designer (or somewhere in between). Don’t forget to check out our [community](https://community.digital.gov.au/c/designsystem) to see what others are doing!
 
-There are four main ways to get started with the Design System;
+There are four ways to get started with the Design System;
 
 - If you have prior experience with `npm`, [use npm to install the components](get-started/npm-install)
 - If you don't have prior experience with `npm`, [visit our Download page to install the components](get-started/download-page)


### PR DESCRIPTION
- Previously our starter docs didn't clarify that prior `npm` knowledge was required to install the components. This has been reworded.

- Text inputs such as postcode and mobile had `type="text"` when then should be `type="number"` and `type="tel"`, respectively

fixes #481 
fixes #496 