### PR TITLE
Fix console warning when building

### DIFF
--- a/content/components/_all.yml
+++ b/content/components/_all.yml
@@ -1550,7 +1550,7 @@ form:
   related:
     - body
     - text-inputs
-    - control inputs
+    - control-input
     - select
   related-articles:
     - TODO


### PR DESCRIPTION
Control inputs was named incorrectly in the `all.yml` file, causing console warning when building
Will fix this:


![image](https://user-images.githubusercontent.com/20184809/55377082-1ee3a400-555f-11e9-9f41-24e024df668c.png)
