### PR TITLE
Make chameleon template route dynamic

### DIFF
--- a/src/assets/js/chameleon.js
+++ b/src/assets/js/chameleon.js
@@ -134,12 +134,10 @@ function ApplyColors( queryString ) {
  * @param   {string} query - The query string, usually window.location.search
  */
 function ApplyQueryToIframe( query ){
-	// These two lines are hacky and should be replaced
-	var template = templateName === 'home' ? '' : '/' + templateName;
-	var iframeQuery = template + query.replace( '&palette=on&a11y=on', '' );
+	var templateEndpoint = '/' + templateName;
+	var iframeQuery = query.replace( '&palette=on&a11y=on', '' );
+	var iframeSrc = isCloud ? 'http://localhost:3000/chameleon' + templateEndpoint : '/chameleon' + templateEndpoint;
 
-	// Need to fix this up
-	var iframeSrc = isCloud ? "http://localhost:3000/chameleon" : "/chameleon";
 	iframe.src = iframeSrc + iframeQuery;
 }
 

--- a/src/layout/customise/page.js
+++ b/src/layout/customise/page.js
@@ -24,13 +24,16 @@ const Customise = ({ _ID, _relativeURL, _parseYaml }) => {
 	const template = templates[templateID];
 
 	const pagetitle = `Customise ${ template.name } page template`;
-
-	const description = `Customise ${ template.name.toLowerCase() } page template with different colour blindness filters, custom colour schemes and preset palettes.`;
+	
+	const templateNameLowerCase = template.name.toLowerCase();
+	const description = `Customise ${ templateNameLowerCase } page template with different colour blindness filters, custom colour schemes and preset palettes.`;
 
 	const isCloud = process.env.NODE_ENV === "master" || process.env.NODE_ENV === "develop";
+
+	// What template page do we want to serve?
 	const iframeSrc = isCloud
-		? "/chameleon"
-		: "http://localhost:3000/chameleon";
+		? `/chameleon/${ templateNameLowerCase }`
+		: `http://localhost:3000/chameleon/${ templateNameLowerCase }`;
 
 	const headContent = `
 <meta charset="utf-8">


### PR DESCRIPTION
This is the final step, linked to: https://github.com/govau/chameleon/pull/139 so that chameleon will load the correct template instead of hard coding the `home` template the whole time.

With this PR chameleon will serve the correct template if it is in the `templates/` folder.