### PR TITLE
update discussion callout btnurl to accept a full url 

### DIFF
--- a/content/components/accordion/discussion/community-intro.md
+++ b/content/components/accordion/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/accordion
 btntype: secondary
 ---
 

--- a/content/components/accordion/discussion/github-intro.md
+++ b/content/components/accordion/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/accordion
 btntype: secondary
 ---
 

--- a/content/components/animate/discussion/community-intro.md
+++ b/content/components/animate/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/animate
 btntype: secondary
 ---
 

--- a/content/components/animate/discussion/github-intro.md
+++ b/content/components/animate/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/animate
 btntype: secondary
 ---
 

--- a/content/components/body/discussion/community-intro.md
+++ b/content/components/body/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/body
 btntype: secondary
 ---
 

--- a/content/components/body/discussion/github-intro.md
+++ b/content/components/body/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/body
 btntype: secondary
 ---
 

--- a/content/components/breadcrumbs/discussion/community-intro.md
+++ b/content/components/breadcrumbs/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/breadcrumbs
 btntype: secondary
 ---
 

--- a/content/components/breadcrumbs/discussion/github-intro.md
+++ b/content/components/breadcrumbs/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/breadcrumbs
 btntype: secondary
 ---
 

--- a/content/components/buttons/discussion/community-intro.md
+++ b/content/components/buttons/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/buttons
 btntype: secondary
 ---
 

--- a/content/components/buttons/discussion/github-intro.md
+++ b/content/components/buttons/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/buttons
 btntype: secondary
 ---
 

--- a/content/components/callout/discussion/community-intro.md
+++ b/content/components/callout/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/callout
 btntype: secondary
 ---
 

--- a/content/components/callout/discussion/github-intro.md
+++ b/content/components/callout/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/callout
 btntype: secondary
 ---
 

--- a/content/components/control-input/discussion/community-intro.md
+++ b/content/components/control-input/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/control-input
 btntype: secondary
 ---
 

--- a/content/components/control-input/discussion/github-intro.md
+++ b/content/components/control-input/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/control-input
 btntype: secondary
 ---
 

--- a/content/components/core/discussion/community-intro.md
+++ b/content/components/core/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/core
 btntype: secondary
 ---
 

--- a/content/components/core/discussion/github-intro.md
+++ b/content/components/core/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/core
 btntype: secondary
 ---
 

--- a/content/components/cta-link/discussion/community-intro.md
+++ b/content/components/cta-link/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/discussion
 btntype: secondary
 ---
 

--- a/content/components/cta-link/discussion/github-intro.md
+++ b/content/components/cta-link/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/cta-link
 btntype: secondary
 ---
 

--- a/content/components/direction-links/discussion/community-intro.md
+++ b/content/components/direction-links/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/direction-links
 btntype: secondary
 ---
 

--- a/content/components/direction-links/discussion/github-intro.md
+++ b/content/components/direction-links/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/direction-links
 btntype: secondary
 ---
 

--- a/content/components/footer/discussion/community-intro.md
+++ b/content/components/footer/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/footer
 btntype: secondary
 ---
 

--- a/content/components/footer/discussion/github-intro.md
+++ b/content/components/footer/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/footer
 btntype: secondary
 ---
 

--- a/content/components/form/discussion/community-intro.md
+++ b/content/components/form/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/form
 btntype: secondary
 ---
 

--- a/content/components/form/discussion/github-intro.md
+++ b/content/components/form/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/form
 btntype: secondary
 ---
 

--- a/content/components/grid-12/discussion/community-intro.md
+++ b/content/components/grid-12/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/grid-12
 btntype: secondary
 ---
 

--- a/content/components/grid-12/discussion/github-intro.md
+++ b/content/components/grid-12/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/grid-12
 btntype: secondary
 ---
 

--- a/content/components/header/discussion/community-intro.md
+++ b/content/components/header/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/header
 btntype: secondary
 ---
 

--- a/content/components/header/discussion/github-intro.md
+++ b/content/components/header/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/header
 btntype: secondary
 ---
 

--- a/content/components/header/rationale/todo.md
+++ b/content/components/header/rationale/todo.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/header
 btntype: secondary
 ---
 

--- a/content/components/headings/discussion/community-intro.md
+++ b/content/components/headings/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/headings
 btntype: secondary
 ---
 

--- a/content/components/headings/discussion/github-intro.md
+++ b/content/components/headings/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/headings
 btntype: secondary
 ---
 

--- a/content/components/inpage-nav/discussion/community-intro.md
+++ b/content/components/inpage-nav/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/inpage-nav
 btntype: secondary
 ---
 

--- a/content/components/inpage-nav/discussion/github-intro.md
+++ b/content/components/inpage-nav/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/inpage-nav
 btntype: secondary
 ---
 

--- a/content/components/keyword-list/discussion/community-intro.md
+++ b/content/components/keyword-list/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/keyword-list
 btntype: secondary
 ---
 

--- a/content/components/keyword-list/discussion/github-intro.md
+++ b/content/components/keyword-list/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/keyword-list
 btntype: secondary
 ---
 

--- a/content/components/keyword-list/rationale/todo.md
+++ b/content/components/keyword-list/rationale/todo.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/keyword-list
 btntype: secondary
 ---
 

--- a/content/components/link-list/discussion/community-intro.md
+++ b/content/components/link-list/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/link-list
 btntype: secondary
 ---
 

--- a/content/components/link-list/discussion/github-intro.md
+++ b/content/components/link-list/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/link-list
 btntype: secondary
 ---
 

--- a/content/components/link-list/rationale/todo.md
+++ b/content/components/link-list/rationale/todo.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/link-list
 btntype: secondary
 ---
 

--- a/content/components/main-nav/discussion/community-intro.md
+++ b/content/components/main-nav/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/main-nav
 btntype: secondary
 ---
 

--- a/content/components/main-nav/discussion/github-intro.md
+++ b/content/components/main-nav/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/main-nav
 btntype: secondary
 ---
 

--- a/content/components/page-alerts/discussion/community-intro.md
+++ b/content/components/page-alerts/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/page-alerts
 btntype: secondary
 ---
 

--- a/content/components/page-alerts/discussion/github-intro.md
+++ b/content/components/page-alerts/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/page-alerts
 btntype: secondary
 ---
 

--- a/content/components/progress-indicator/discussion/community-intro.md
+++ b/content/components/progress-indicator/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/progress-indicator
 btntype: secondary
 ---
 

--- a/content/components/progress-indicator/discussion/github-intro.md
+++ b/content/components/progress-indicator/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/progress-indicator
 btntype: secondary
 ---
 

--- a/content/components/progress-indicator/rationale/todo.md
+++ b/content/components/progress-indicator/rationale/todo.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/progress-indicator
 btntype: secondary
 ---
 

--- a/content/components/responsive-media/discussion/community-intro.md
+++ b/content/components/responsive-media/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/responsive-media
 btntype: secondary
 ---
 

--- a/content/components/responsive-media/discussion/github-intro.md
+++ b/content/components/responsive-media/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/responsive-media
 btntype: secondary
 ---
 

--- a/content/components/responsive-media/rationale/todo.md
+++ b/content/components/responsive-media/rationale/todo.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/responsive-media
 btntype: secondary
 ---
 

--- a/content/components/select/discussion/community-intro.md
+++ b/content/components/select/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/select
 btntype: secondary
 ---
 

--- a/content/components/select/discussion/github-intro.md
+++ b/content/components/select/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/select
 btntype: secondary
 ---
 

--- a/content/components/side-nav/discussion/community-intro.md
+++ b/content/components/side-nav/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/side-nav
 btntype: secondary
 ---
 

--- a/content/components/side-nav/discussion/github-intro.md
+++ b/content/components/side-nav/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/side-nav
 btntype: secondary
 ---
 

--- a/content/components/skip-link/discussion/community-intro.md
+++ b/content/components/skip-link/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/skip-link
 btntype: secondary
 ---
 

--- a/content/components/skip-link/discussion/github-intro.md
+++ b/content/components/skip-link/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/skip-link
 btntype: secondary
 ---
 

--- a/content/components/table/discussion/community-intro.md
+++ b/content/components/table/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/table
 btntype: secondary
 ---
 

--- a/content/components/table/discussion/github-intro.md
+++ b/content/components/table/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/table
 btntype: secondary
 ---
 

--- a/content/components/tags/discussion/community-intro.md
+++ b/content/components/tags/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/tags
 btntype: secondary
 ---
 

--- a/content/components/tags/discussion/github-intro.md
+++ b/content/components/tags/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/tags
 btntype: secondary
 ---
 

--- a/content/components/text-inputs/discussion/community-intro.md
+++ b/content/components/text-inputs/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/
+btnurl: https://community.digital.gov.au/t/text-inputs
 btntype: secondary
 ---
 

--- a/content/components/text-inputs/discussion/github-intro.md
+++ b/content/components/text-inputs/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-components/tree/master/packages/
+btnurl: https://github.com/govau/design-system-components/tree/master/packages/text-inputs
 btntype: secondary
 ---
 

--- a/content/templates/content/discussion/community-intro.md
+++ b/content/templates/content/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/content-page
+btnurl: https://community.digital.gov.au/t/content-page/1135
 btntype: secondary
 ---
 

--- a/content/templates/content/discussion/github-intro.md
+++ b/content/templates/content/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-starter/
+btnurl: https://github.com/govau/design-system-starter/tree/master/docs/basic
 btntype: secondary
 ---
 

--- a/content/templates/content/discussion/github-intro.md
+++ b/content/templates/content/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://community.digital.gov.au/t/content-page/1135
+btnurl: https://github.com/govau/design-system-starter/tree/master/docs
 btntype: secondary
 ---
 

--- a/content/templates/content/discussion/github-intro.md
+++ b/content/templates/content/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-starter/tree/master/docs/basic
+btnurl: https://community.digital.gov.au/t/content-page/1135
 btntype: secondary
 ---
 

--- a/content/templates/content/rationale/todo.md
+++ b/content/templates/content/rationale/todo.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/content-page
+btnurl: https://community.digital.gov.au/t/content-page/1135
 btntype: secondary
 ---
 

--- a/content/templates/form/discussion/community-intro.md
+++ b/content/templates/form/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/form-page
+btnurl: https://community.digital.gov.au/t/form-page/1136/11
 btntype: secondary
 ---
 

--- a/content/templates/form/discussion/github-intro.md
+++ b/content/templates/form/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-starter/
+btnurl: https://github.com/govau/design-system-starter/tree/master/docs/form
 btntype: secondary
 ---
 

--- a/content/templates/form/rationale/todo.md
+++ b/content/templates/form/rationale/todo.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/form-page
+btnurl: https://community.digital.gov.au/t/form-page/1136/11
 btntype: secondary
 ---
 

--- a/content/templates/home/discussion/community-intro.md
+++ b/content/templates/home/discussion/community-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/home-page
+btnurl: https://community.digital.gov.au/t/home-page/817
 btntype: secondary
 ---
 

--- a/content/templates/home/discussion/github-intro.md
+++ b/content/templates/home/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-starter
+btnurl: https://github.com/govau/design-system-starter/tree/master/docs
 btntype: secondary
 ---
 

--- a/content/templates/home/discussion/github-intro.md
+++ b/content/templates/home/discussion/github-intro.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: GitHub
-btnurl: https://github.com/govau/design-system-starter/
+btnurl: https://github.com/govau/design-system-starter
 btntype: secondary
 ---
 

--- a/content/templates/home/rationale/todo.md
+++ b/content/templates/home/rationale/todo.md
@@ -1,7 +1,7 @@
 ---
 layout: component/discussion-callout
 btntext: Community
-btnurl: https://community.digital.gov.au/t/home-page
+btnurl: https://community.digital.gov.au/t/home-page/817
 btntype: secondary
 ---
 

--- a/src/layout/component/discussion-callout.js
+++ b/src/layout/component/discussion-callout.js
@@ -11,7 +11,7 @@ import React     from 'react';
 const CalloutWithButton = ({ btntext, btnurl, btntype, _body, _parents, _ID }) => {
 
 	const module = GetModule( _parents, _ID );
-{
+
 	return (
 		
 		<div className="calloutWithButton calloutWithButton__text">
@@ -23,7 +23,7 @@ const CalloutWithButton = ({ btntext, btnurl, btntype, _body, _parents, _ID }) =
 			</div>
 		</div>
 	);
-}
+
 }
 
 

--- a/src/layout/component/discussion-callout.js
+++ b/src/layout/component/discussion-callout.js
@@ -10,7 +10,6 @@ import React     from 'react';
  */
 const CalloutWithButton = ({ btntext, btnurl, btntype, _body, _parents, _ID }) => {
 
-	const module = GetModule( _parents, _ID );
 
 	return (
 		

--- a/src/layout/component/discussion-callout.js
+++ b/src/layout/component/discussion-callout.js
@@ -11,17 +11,19 @@ import React     from 'react';
 const CalloutWithButton = ({ btntext, btnurl, btntype, _body, _parents, _ID }) => {
 
 	const module = GetModule( _parents, _ID );
-
+{
 	return (
+		
 		<div className="calloutWithButton calloutWithButton__text">
 			<div className="col-sm-6 col-md-7">
 				{ _body }
 			</div>
 			<div className="col-sm-6 col-md-offset-1 col-md-4 calloutWithButton__buttons">
-				<AUbutton link={ `${ btnurl }${ module ? module : '' }` } as={ btntype } block>{ btntext }</AUbutton>
+				<AUbutton link={ `${ btnurl }` } as={ btntype } block>{ btntext }</AUbutton>
 			</div>
 		</div>
 	);
+}
 }
 
 


### PR DESCRIPTION


callout-discussion.js was updated to remove of the module name from being appended to the url  via code - this was causing an issue with the template discussion links.  This change allows the btnurl prop to accept the full url.  

after the above changed all necessary urls were updated to include the full url. 