### PR TITLE
Use cloud.gov.au naming convention for env vars in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
               mv package-lock.json deploy/
               mv .deploy/manifest-staging.yml deploy/
               cd deploy/
-              cf login -a $CF_API_STAGING -o $CF_ORG_STAGING -s $CF_SPACE_STAGING -u $CF_USER_STAGING -p $CF_PASSWORD_STAGING
+              cf login -a $CF_API_STAGING -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_STAGING
               cf zero-downtime-push designsystem -f manifest-staging.yml
 
 
@@ -80,7 +80,7 @@ jobs:
               mv package-lock.json deploy/
               mv .deploy/manifest-prod.yml deploy/
               cd deploy/
-              cf login -a $CF_API_PROD -o $CF_ORG_PROD -s $CF_SPACE_PROD -u $CF_USER_PROD -p $CF_PASSWORD_PROD
+              cf login -a $CF_API_PROD -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_PROD
               cf zero-downtime-push designsystem -f manifest-prod.yml
 
 
@@ -104,7 +104,7 @@ jobs:
               mv package-lock.json deploy/
               mv .deploy/manifest-testing.yml deploy/
               cd deploy/
-              cf login -a $CF_API_STAGING -o $CF_ORG_STAGING -s $CF_SPACE_STAGING -u $CF_USER_STAGING -p $CF_PASSWORD_STAGING
+              cf login -a $CF_API_STAGING -o $CF_ORG -s $CF_SPACE -u $CF_USERNAME -p $CF_PASSWORD_STAGING
               cf zero-downtime-push designsystem-$CIRCLE_BRANCH -f manifest-testing.yml
 
 


### PR DESCRIPTION
cloud.gov.au will start managing this project's CF_* env vars in circleci, and to
make it easier for us we need to have a standard naming convention for environment
variables across all repos we look after.
Nothing should change for this project, this is really just house cleaning to use
the standard names.

The standard naming convention is:
CF_API_PROD
CF_API_STAGING
CF_ORG
CF_PASSWORD_PROD
CF_PASSWORD_STAGING
CF_SPACE
CF_USERNAME

After this has been merged we can remove any CF_* env vars in circleci that arent
in the above list.