### PR TITLE
Use cloud.gov.au naming convention for env vars in circleci

### DIFF
--- a/content/templates/home/tips.md
+++ b/content/templates/home/tips.md
@@ -2,7 +2,7 @@
 
 ### Structure
 
-- Variations of the `.au-body` selector such as `.au-body--alt or .au-body--dark` or a combination of them can be used to slice up the page into horizontal sections of different shades. These contrasting sections can make it easier to categorise different sections on the page.
+- Variations of the `.au-body` selector such as `.au-body--alt or .au-body--dark` or a combination of them can be used to slice up the page into horizontal sections of different shades. These variations provide contrast that can be used to reinforce visual clustering amongst different sections of the home page.
 
 
 


### PR DESCRIPTION
Thanks @gordcorp 

```
cloud.gov.au will start managing this project's CF_* env vars in circleci, and to
make it easier for us we need to have a standard naming convention for environment
variables across all repos we look after.
Nothing should change for this project, this is really just house cleaning to use
the standard names.

The standard naming convention is:
CF_API_PROD
CF_API_STAGING
CF_ORG
CF_PASSWORD_PROD
CF_PASSWORD_STAGING
CF_SPACE
CF_USERNAME

After this has been merged we can remove any CF_* env vars in circleci that arent
in the above list.
```