### PR TITLE
Change sketch download link to github repo

### DIFF
--- a/content/download/intro-designers-sidebar.md
+++ b/content/download/intro-designers-sidebar.md
@@ -3,6 +3,6 @@ layout: download/intro-sidebar
 title: Resources
 links:
   - title: Sketch Design Files
-    download: /assets/files/AuDS_v1.1.0.zip
+    download: https://github.com/govau/design-system-sketch-file/blob/master/public/auds.zip?raw=true
     icon: sketch
 ---

--- a/src/layout/download/intro-sidebar.js
+++ b/src/layout/download/intro-sidebar.js
@@ -11,7 +11,7 @@ const IntroSidebar = ({ links, title, _relativeURL }) => (
 		<h2> {title} </h2>
 		<AUlinkList items={
 			links.map( link => ({
-				link: _relativeURL( link.download ),
+				link: link.download,
 				text: link.title,
 				className: link.icon ? ` icon icon--${link.icon} ` : ''
 			}))


### PR DESCRIPTION
We should link to the version controlled sketch file in the [design system sketch file](https://github.com/govau/design-system-sketch-file) repo master branch
fixes #614