### PR TITLE
Moved back arrow to render prior to text label.

### DIFF
--- a/content/components/direction-links/default.md
+++ b/content/components/direction-links/default.md
@@ -10,7 +10,7 @@ code:
       -->
 
       <a class="au-direction-link" href="#">
-        Back<span class="au-direction-link__arrow au-direction-link__arrow--left" aria-hidden="true"></span>
+        <span class="au-direction-link__arrow au-direction-link__arrow--left" aria-hidden="true"></span>Back
       </a>
       <a class="au-direction-link" href="#">
         Next<span class="au-direction-link__arrow" aria-hidden="true"></span>


### PR DESCRIPTION
First reported at:
https://community.digital.gov.au/t/direction-links/77/3