### PR TITLE
Fix typo in card react example docs

### DIFF
--- a/content/components/card/card-link.md
+++ b/content/components/card/card-link.md
@@ -30,7 +30,7 @@ code:
         <AUcard className="au-body" clickable shadow>
             <img className="au-responsive-media-img" src="https://designsystem.gov.au/assets/img/placeholder/600X260.png" alt="" />
                 <AUcardInner>
-                    <AUcardTitle level="3"><AUcardLink link="#" text="Title of article" />      </AUcardTitle>
+                    <AUcardTitle level="3"><AUcardLink link="#" text="Title of article" /></AUcardTitle>
                         <p>Some text</p>
                 </AUcardInner>
         </AUcard>

--- a/content/components/card/card-link.md
+++ b/content/components/card/card-link.md
@@ -30,7 +30,7 @@ code:
         <AUcard className="au-body" clickable shadow>
             <img className="au-responsive-media-img" src="https://designsystem.gov.au/assets/img/placeholder/600X260.png" alt="" />
                 <AUcardInner>
-                    <AUcardTitle level="3"><AUcardLink link="#" text="Title of article" /></h3>
+                    <AUcardTitle level="3"><AUcardLink link="#" text="Title of article" />      </AUcardTitle>
                         <p>Some text</p>
                 </AUcardInner>
         </AUcard>

--- a/content/components/card/card-list.md
+++ b/content/components/card/card-list.md
@@ -37,16 +37,16 @@ code:
         <div class="row">
             <ul className="au-card-list au-card-list--matchheight">
                     <li className="col-sm-3 col-xs-6">
-                        <AUcard >
+                        <AUcard>
                             <AUcardInner>
-                                    <h3 >Card 1</h3>
+                                    <h3>Card 1</h3>
                             </AUcardInner>
                         </AUcard>
                     </li>
                     <li className="col-sm-3 col-xs-6">
                         <AUcard>
                             <AUcardInner>
-                                    <h3 >Card 2</h3>
+                                    <h3>Card 2</h3>
                             </AUcardInner>
                         </AUcard>
                     </li>

--- a/content/components/card/default.md
+++ b/content/components/card/default.md
@@ -25,7 +25,7 @@ code:
 
         <AUcard>
             <AUcardInner>
-                <AUcardTitle>Card Title</h3>
+                <AUcardTitle>Card Title</AUcardTitle>
                 <p>Some text</p>
                 <p>Additional content</p>
             </AUcardInner>

--- a/content/components/card/footer.md
+++ b/content/components/card/footer.md
@@ -12,7 +12,7 @@ code:
 
         <div class="au-card au-body">
             <div class="au-card__inner">
-                <h3 class="au-card__title">Card title</AUcardTitle>
+                <h3 class="au-card__title">Card title</h3>
                 <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. In, voluptatibus.</p>
             </div>
             <div class="au-card__footer">

--- a/content/components/card/footer.md
+++ b/content/components/card/footer.md
@@ -12,7 +12,7 @@ code:
 
         <div class="au-card au-body">
             <div class="au-card__inner">
-                <h3 class="au-card__title">Card title</h3>
+                <h3 class="au-card__title">Card title</AUcardTitle>
                 <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. In, voluptatibus.</p>
             </div>
             <div class="au-card__footer">
@@ -32,7 +32,7 @@ code:
 
         <AUcard className="au-body">
             <AUcardInner>
-                <AUcardTitle level="3"> Card Title</AUcardTitle>
+                <AUcardTitle level="3">Card Title</AUcardTitle>
                 <p>Lorem ipsum dolor, sit amet consectetur adipisicing elit. In, voluptatibus.</p>
             </AUcardInner>
             <AUcardFooter alt>

--- a/content/components/card/header.md
+++ b/content/components/card/header.md
@@ -29,7 +29,7 @@ code:
 
         <AUcard className="au-body">
             <AUcardInner>
-                <AUcardHeader level="3">Card Title</h3>
+                <AUcardHeader level="3">Card Title</AUcardTitle>
                 <p>Some text</p>
                 <p>Additional content</p>
             </AUcardInner>

--- a/content/components/card/header.md
+++ b/content/components/card/header.md
@@ -20,7 +20,7 @@ code:
 
   - React: |
         /*
-            Light: <AUcardHeader >
+            Light: <AUcardHeader>
             Dark:  <AUcardHeader dark>
             Alt:   <AUcardHeader alt>
         */

--- a/content/components/card/header.md
+++ b/content/components/card/header.md
@@ -29,7 +29,7 @@ code:
 
         <AUcard className="au-body">
             <AUcardInner>
-                <AUcardHeader level="3">Card Title</AUcardTitle>
+                <AUcardHeader level="3">Card Title</AUcardHeader>
                 <p>Some text</p>
                 <p>Additional content</p>
             </AUcardInner>


### PR DESCRIPTION
`<AUcardTitle>` is closed with a `<h3>` instead of `<\AUcardTitle>` in the react code examples for the card component