### PR TITLE
Update component page side nav link colours

### DIFF
--- a/src/sass/components/_navigation-accordion.scss
+++ b/src/sass/components/_navigation-accordion.scss
@@ -27,12 +27,13 @@
 		& > a {
 			@include AU-fontgrid( xs, nospace );
 			@include AU-space( padding, 0.75unit 1unit );
+			color: darken( $AU-color-foreground-action, 1% )
 		}
 	}
 
 	.au-accordion__body-wrapper {
 		padding: 2px 3px;
-		background-color: lighten($AU-color-background-alt-shade, 3%);
+		background-color: lighten($AU-color-background-alt-shade, 1%);
 		border-top: 1px solid darken($AU-color-background-shade, 15%);
 	}
 

--- a/src/sass/components/_navigation-accordion.scss
+++ b/src/sass/components/_navigation-accordion.scss
@@ -32,7 +32,7 @@
 
 	.au-accordion__body-wrapper {
 		padding: 2px 3px;
-		background-color: $AU-color-background-alt-shade;
+		background-color: lighten($AU-color-background-alt-shade, 3%);
 		border-top: 1px solid darken($AU-color-background-shade, 15%);
 	}
 


### PR DESCRIPTION
The link colour against the background was falling slightly short of WCAG AA.
Have adjusted both values slightly

Thanks James Offer for the offering [the suggestion](https://community.digital.gov.au/t/colour-contrast-on-design-system-navigation/2304)!