### PR TITLE
Added missing comma in example

### DIFF
--- a/content/components/tags/default.md
+++ b/content/components/tags/default.md
@@ -34,7 +34,7 @@ code:
         {
           link: '#',
           text: 'baz',
-          className: ''
+          className: '',
           attributeOptions: {
             onClick: () => {console.log('clicked')},
           }


### PR DESCRIPTION
There's a comma missing in the tags with links react code example.

Hope this helps! 🚀

I assumed develop was the best branch for something as small as this.